### PR TITLE
Gestion Em - Base de données

### DIFF
--- a/bdd/nvs_tables.sql
+++ b/bdd/nvs_tables.sql
@@ -291,6 +291,7 @@ CREATE TABLE `banque_as_compagnie` (
 CREATE TABLE `banque_compagnie` (
   `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `id_perso` int(11) NOT NULL,
+  `bank_id` int(11) NOT NULL,
   `montant` int(11) NOT NULL default '0',
   `demande_emprunt` int(11) NOT NULL default '0',
   `montant_emprunt` int(11) NOT NULL default '0',
@@ -811,7 +812,7 @@ CREATE TABLE `em_creer_compagnie` (
   `nom_compagnie` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `description_compagnie` text CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `camp` int(11) NOT NULL,
-  `votes_result` tinyint NOT NULL DEFAULT '0',
+  `votes_result` tinyint NULL,
   `soft_delete` datetime NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
Oubli dans les modifications de tables :
- Ajout de la colonne manquante "bank_id" pour la table "banque_compagnie"
- Modification de la colonne "votes_result" en NULL au lieu de NOT NULL

A appliquer :
ALTER TABLE `banque_compagnie` ADD `bank_id` INT NOT NULL AFTER `id_perso`;
ALTER TABLE `em_creer_compagnie` CHANGE `votes_result` `votes_result` TINYINT(4) NULL;