### PR TITLE
bug ajout armes et recrutement grouillot

### DIFF
--- a/jeu/batiment.php
+++ b/jeu/batiment.php
@@ -3,6 +3,7 @@
 require_once("../fonctions.php");
 require_once("f_carte.php");
 require_once("f_action.php");
+require_once("../mvc/model/Weapon.php");
 
 $mysqli = db_connexion();
 
@@ -172,8 +173,8 @@ if($dispo == '1' || $admin){
 											if($or >= $coutOr_arme){
 
 												// insertion perso_as_arme
-												$sql_i = "INSERT INTO perso_as_arme VALUES('$id_perso','$id_arme','0')";
-												$mysqli->query($sql_i);
+												$addWeapon = new Weapon();
+												$addWeapon = $addWeapon->addWeapon($id_perso,$id_arme,0);
 
 												// mis à jour or/charge perso
 												$sql_m = "UPDATE perso SET or_perso=or_perso-$coutOr_arme, charge_perso=charge_perso+$poids_arme, pa_perso=pa_perso-2 WHERE id_perso='$id_perso'";

--- a/jeu/gestion_grouillot.php
+++ b/jeu/gestion_grouillot.php
@@ -4,6 +4,7 @@ require_once("../fonctions.php");
 require_once("f_combat.php");
 require_once("f_carte.php");
 require_once("f_recrutement.php");
+require_once("../mvc/model/Building.php");
 
 $mysqli = db_connexion();
 
@@ -370,9 +371,9 @@ if($dispo == '1' || $admin){
 										$sql = "DELETE FROM `cv` WHERE IDActeur_cv=$matricule AND IDCible_cv=$matricule AND nomActeur_cv LIKE '%renvoyé%'";
 										$mysqli->query($sql);
 
-										// Insertion perso dans batiment 
-										$sql = "INSERT INTO perso_in_batiment VALUES ('$matricule','$id_instance_bat')";
-										$mysqli->query($sql);
+										// Insertion perso dans batiment
+										$enterInBat = new Building();
+										$enterInBat = $enterInBat->insertCharacters([$matricule],$id_instance_bat);
 
 										// On téléporte le perso
 										$sql = "UPDATE perso SET x_perso=$x_instance, y_perso=$y_instance WHERE id_perso='$matricule'";

--- a/mvc/controller/authController.php
+++ b/mvc/controller/authController.php
@@ -12,7 +12,6 @@ require_once("../mvc/model/Weapon.php");
 require_once("../mvc/model/Skill.php");
 require_once("../mvc/model/Notification.php");
 require_once("../mvc/model/Event.php");
-require_once("../mvc/model/User.php");
 
 require_once("../app/validator/formValidator.php");
 require_once("controller.php");
@@ -31,7 +30,7 @@ class AuthController extends Controller
     }
 	
 	/**
-     * Display the presentation page
+     * Display the register page
      *
      * @return view
      */
@@ -71,7 +70,7 @@ class AuthController extends Controller
     }
 	
 	/**
-     * Display the FAQ page
+     * Store de registration
      *
      * @return view
      */
@@ -243,7 +242,8 @@ class AuthController extends Controller
 				$leader->recup_perso = $unitLeader->recup_unite;
 				$leader->protec_perso = $unitLeader->protection_unite;
 				$leader->pa_perso = $unitLeader->pa_unite;
-				$leader->image_perso = $unitLeader->image_unite.'_'.$camp->img_suffix.$unitInfantry->img_extension;
+				$leader->paMax_perso = $unitLeader->pa_unite;
+				$leader->image_perso = $unitLeader->image_unite.'_'.$camp->img_suffix.$unitLeader->img_extension;
 				$leader->or_perso = 20;
 				$leader->chef = 1;
 				$leader->clan = $camp->id;
@@ -265,6 +265,7 @@ class AuthController extends Controller
 				$infantry->recup_perso = $unitInfantry->recup_unite;
 				$infantry->protec_perso = $unitInfantry->protection_unite;
 				$infantry->pa_perso = $unitInfantry->pa_unite;
+				$infantry->paMax_perso = $unitInfantry->pa_unite;
 				$infantry->image_perso = $unitInfantry->image_unite.'_'.$camp->img_suffix.$unitInfantry->img_extension;
 				$infantry->or_perso = 0;
 				$infantry->chef = 0;
@@ -411,34 +412,5 @@ class AuthController extends Controller
 			header('location:?action=register');
 			die();
 		}
-    }
-	
-	/**
-     * Display the Forum page
-     *
-     * @return view
-     */
-    public function forum()
-    {
-		require_once('../mvc/view/home/faq.php');
-    }
-	
-	/**
-     * Display the ranking page
-     *
-     * @return view
-     */
-    public function ranking()
-    {
-    }
-	
-	/**
-     * Display the Forum page
-     *
-     * @return view
-     */
-    public function credits()
-    {
-		require_once('../mvc/view/home/credits.php');
     }
 }


### PR DESCRIPTION
### Correction de la page de recrutement
- Ajout des modèles nécessaires à la création d'un personnage ("Character","Camp","Building","Unit","MailFile","Grade","Weapon","Skill","Event")
- Suppression des redondances pour la création de perso par type d'unité
- Mise en place d'une création de perso "générique" avec des variables liées à chaque unité
- Allègement de la page (-60% de poids)

### Correction dans la gestion des grouillots
- Ajout du modèle "building"
- Correction de l'insertion d'un grouillot dans un bâtiment lors de la réactivation après une "mise au placard"

### Correction d'un bug lié à l'achat d'arme
- Ajout du modèle "Weapon"
- Ajout de la fonction générique d'ajout d'arme ### MISC :
- Mise à jour de la page "inscription" avec le nombre de PA Max lors de la création des persos joueur